### PR TITLE
fix entrypoint resolution on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,17 @@ jobs:
       matrix:
         deno:
           - canary
-    runs-on: ubuntu-latest
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: denoland/setup-deno@v1.0.0
         with:
           deno-version: ${{ matrix.deno }}
       - run: make fmt-check
+        if: matrix.os == 'ubuntu-latest'
       - run: make lint
+        if: matrix.os == 'ubuntu-latest'
       - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage
 dist
 /.vscode
+/.vim
 
 # parcel
 .parcel-cache

--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -1,4 +1,4 @@
-import { resolve } from "./deps.ts";
+import { resolve, toFileUrl } from "./deps.ts";
 import { logger } from "./logger_util.ts";
 import { load } from "https://deno.land/x/esbuild_loader@v0.12.8/mod.ts";
 import { denoPlugin } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/fa2219c3df9494da6c33e3e4dffb1a33b5cc0345/mod.ts";
@@ -10,7 +10,7 @@ export async function bundleByEsbuild(
   const { build } = await load(wasmPath);
 
   const bundle = await build({
-    entryPoints: [resolve(path)],
+    entryPoints: [toFileUrl(resolve(path)).href],
     plugins: [denoPlugin()],
     bundle: true,
   });

--- a/deps.ts
+++ b/deps.ts
@@ -6,6 +6,7 @@ export {
   join,
   relative,
   resolve,
+  toFileUrl,
 } from "https://deno.land/std@0.95.0/path/mod.ts";
 export { ensureDir } from "https://deno.land/std@0.95.0/fs/ensure_dir.ts";
 export { parse as parseFlags } from "https://deno.land/std@0.95.0/flags/mod.ts";

--- a/install_util_test.ts
+++ b/install_util_test.ts
@@ -1,10 +1,20 @@
 import { assertEquals } from "./test_deps.ts";
+import { join } from "./deps.ts";
 import { wasmCacheDir } from "./install_util.ts";
 
 Deno.test("wasmCacheDir - returns cache dir for esbuild wasm", () => {
   const homedir = (os: typeof Deno.build.os) =>
     os === "windows" ? "/userprofile" : "/home/foo";
-  assertEquals(wasmCacheDir("windows", homedir), "/userprofile/.deno/packup");
-  assertEquals(wasmCacheDir("linux", homedir), "/home/foo/.deno/packup");
-  assertEquals(wasmCacheDir("darwin", homedir), "/home/foo/.deno/packup");
+  assertEquals(
+    wasmCacheDir("windows", homedir),
+    join("/userprofile", ".deno/packup"),
+  );
+  assertEquals(
+    wasmCacheDir("linux", homedir),
+    join("/home/foo", ".deno/packup"),
+  );
+  assertEquals(
+    wasmCacheDir("darwin", homedir),
+    join("/home/foo", ".deno/packup"),
+  );
 });

--- a/test.js
+++ b/test.js
@@ -1,1 +1,0 @@
-import * as jsdom from "https://cdn.skypack.dev/jsdom";

--- a/util_test.ts
+++ b/util_test.ts
@@ -8,6 +8,8 @@ import {
   md5,
 } from "./util.ts";
 
+const normalize = (p: string) => join(p);
+
 Deno.test("md5 - returns md5 of the given data", () => {
   assertEquals(md5("a"), "0cc175b9c0f1b6a831c399e269772661");
   assertEquals(md5("b"), "92eb5ffee6ae2fec3ad71c777531578f");
@@ -16,40 +18,49 @@ Deno.test("md5 - returns md5 of the given data", () => {
 
 Deno.test("getDependencies - returns dependency specifiers", async () => {
   const cwd = Deno.cwd();
-  assertEquals(await getDependencies("testdata/foo.js"), [
-    "file://" + join(cwd, "testdata/bar.js"),
-    "file://" + join(cwd, "testdata/baz.js"),
-    "file://" + join(cwd, "testdata/foo.js"),
-    "https://deno.land/std@0.95.0/_util/assert.ts",
-    "https://deno.land/std@0.95.0/_util/os.ts",
-    "https://deno.land/std@0.95.0/path/_constants.ts",
-    "https://deno.land/std@0.95.0/path/_interface.ts",
-    "https://deno.land/std@0.95.0/path/_util.ts",
-    "https://deno.land/std@0.95.0/path/common.ts",
-    "https://deno.land/std@0.95.0/path/glob.ts",
-    "https://deno.land/std@0.95.0/path/mod.ts",
-    "https://deno.land/std@0.95.0/path/posix.ts",
-    "https://deno.land/std@0.95.0/path/separator.ts",
-    "https://deno.land/std@0.95.0/path/win32.ts",
-  ]);
+  assertEquals(
+    (await getDependencies("testdata/foo.js")).map(normalize),
+    [
+      "file://" + join(cwd, "testdata/bar.js"),
+      "file://" + join(cwd, "testdata/baz.js"),
+      "file://" + join(cwd, "testdata/foo.js"),
+      "https://deno.land/std@0.95.0/_util/assert.ts",
+      "https://deno.land/std@0.95.0/_util/os.ts",
+      "https://deno.land/std@0.95.0/path/_constants.ts",
+      "https://deno.land/std@0.95.0/path/_interface.ts",
+      "https://deno.land/std@0.95.0/path/_util.ts",
+      "https://deno.land/std@0.95.0/path/common.ts",
+      "https://deno.land/std@0.95.0/path/glob.ts",
+      "https://deno.land/std@0.95.0/path/mod.ts",
+      "https://deno.land/std@0.95.0/path/posix.ts",
+      "https://deno.land/std@0.95.0/path/separator.ts",
+      "https://deno.land/std@0.95.0/path/win32.ts",
+    ].map(normalize),
+  );
 });
 
 Deno.test("getLocalDependencies - returns local dependency specifiers", async () => {
   const cwd = Deno.cwd();
-  assertEquals(await getLocalDependencies("testdata/foo.js"), [
-    "file://" + join(cwd, "testdata/bar.js"),
-    "file://" + join(cwd, "testdata/baz.js"),
-    "file://" + join(cwd, "testdata/foo.js"),
-  ]);
+  assertEquals(
+    (await getLocalDependencies("testdata/foo.js")).map(normalize),
+    [
+      "file://" + join(cwd, "testdata/bar.js"),
+      "file://" + join(cwd, "testdata/baz.js"),
+      "file://" + join(cwd, "testdata/foo.js"),
+    ].map(normalize),
+  );
 });
 
 Deno.test("getLocalDependencyPaths - returns local dependency paths", async () => {
   const cwd = Deno.cwd();
-  assertEquals(await getLocalDependencyPaths("testdata/foo.js"), [
-    join(cwd, "testdata/bar.js"),
-    join(cwd, "testdata/baz.js"),
-    join(cwd, "testdata/foo.js"),
-  ]);
+  assertEquals(
+    (await getLocalDependencyPaths("testdata/foo.js")).map(normalize),
+    [
+      join(cwd, "testdata/bar.js"),
+      join(cwd, "testdata/baz.js"),
+      join(cwd, "testdata/foo.js"),
+    ].map(normalize),
+  );
 });
 
 Deno.test("byteSize", () => {


### PR DESCRIPTION
This PR tries to fix the issue reported in #4 

 The entrypoint should be passed as file url format for using [esbuild_deno_loader](https://github.com/lucacasonato/esbuild_deno_loader) correctly, but it's passed as absolute path format. This PR applies `toFileUrl` format before passing the entrypoint to esbuild.

This PR also enables the CI on windows.

closes #4 