### PR TITLE
Feature: Enable Javascript minify

### DIFF
--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -25,7 +25,7 @@ export async function bundleByEsbuild(
     entryPoints: [toFileUrl(resolve(path)).href],
     plugins: [denoPlugin()],
     bundle: true,
-    minfiy: true,
+    minify: true,
   });
 
   return bundle.outputFiles![0].text;

--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -25,6 +25,7 @@ export async function bundleByEsbuild(
     entryPoints: [toFileUrl(resolve(path)).href],
     plugins: [denoPlugin()],
     bundle: true,
+    minfiy: true,
   });
 
   return bundle.outputFiles![0].text;

--- a/bundle_util_test.ts
+++ b/bundle_util_test.ts
@@ -5,5 +5,5 @@ import { wasmPath } from "./install_util.ts";
 Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
   const bundle = await bundleByEsbuild("testdata/foo.js", wasmPath());
 
-  assertStringIncludes(bundle, `console.log("hi");`);
+  assertStringIncludes(bundle, `console.log("hi")`);
 });


### PR DESCRIPTION
Hi,
Intrigued by wanting to minimize the code generated by Packup, I initially thought of using "Terser" (https://terser.org), after running Packup, to reduce the size of the generated JS file...
Then searching in ESBuild documentations I came across the "minify: true" directive of the "build()" function.
So I added that directive to packup and tried to run the build command and indeed it works!

Now, I don't know if you haven't added it for some reason, but in case I send this pull request to add the functionality.