### PR TITLE
fix(livereload_server): migrate to native http server

### DIFF
--- a/livereload_server.ts
+++ b/livereload_server.ts
@@ -1,74 +1,94 @@
-import { serve } from "https://deno.land/std@0.96.0/http/server.ts";
-import {
-  acceptWebSocket,
-  isWebSocketCloseEvent,
-  isWebSocketPingEvent,
-  WebSocket,
-} from "https://deno.land/std@0.96.0/ws/mod.ts";
 import { logger } from "./logger_util.ts";
 
-async function handleWs(sock: WebSocket, eventtarget: EventTarget) {
+function handleWs(sock: WebSocket, eventtarget: EventTarget): void {
   logger.debug("socket connected!");
-  eventtarget.addEventListener("built", async () => {
+  sock.onmessage = (ev) => {
+    logger.debug("ws:Message", ev.data);
+    sock.send(ev.data);
+  };
+  sock.onopen = () => logger.debug("ws:Open");
+  sock.onclose = (ev) => {
+    const { code, reason } = ev;
+    logger.debug("ws:Close", code, reason);
+  };
+  sock.onerror = (ev) => {
+    logger.error("failed to receive frame:", ev);
+    if (canCloseSocket(sock)) {
+      sock.close(1000);
+    }
+  };
+  eventtarget.addEventListener("built", () => {
     logger.debug("got reload event!");
-    if (!sock.isClosed) {
-      await sock.send(JSON.stringify({ type: "reload" }));
-      sock.close(1000).catch(logger.error);
+    if (canCloseSocket(sock)) {
+      sock.send(JSON.stringify({ type: "reload" }));
+      sock.close(1000);
     }
   }, { once: true });
-  try {
-    for await (const ev of sock) {
-      if (typeof ev === "string") {
-        // text message.
-        logger.debug("ws:Text", ev);
-        await sock.send(ev);
-      } else if (ev instanceof Uint8Array) {
-        // binary message.
-        logger.debug("ws:Binary", ev);
-      } else if (isWebSocketPingEvent(ev)) {
-        const [, body] = ev;
-        // ping.
-        logger.debug("ws:Ping", body);
-      } else if (isWebSocketCloseEvent(ev)) {
-        // close.
-        const { code, reason } = ev;
-        logger.debug("ws:Close", code, reason);
-      }
-    }
-  } catch (err) {
-    logger.error(`failed to receive frame: ${err}`);
-
-    if (!sock.isClosed) {
-      await sock.close(1000).catch(logger.error);
-    }
-  }
 }
 
-export async function livereloadServer(port = 35729, eventtarget: EventTarget) {
-  logger.debug(`livereload websocket server is running on port=${port}`);
-  for await (const req of serve(`:${port}`)) {
-    if (req.url === "/livereload.js") {
-      req.respond({
-        body: `
+function canCloseSocket(socket: WebSocket): boolean {
+  return socket.readyState === socket.OPEN;
+}
+
+async function serve(
+  httpConn: Deno.HttpConn,
+  eventtarget: EventTarget,
+  port: number,
+): Promise<void> {
+  const requestEvent = await httpConn.nextRequest();
+  if (requestEvent == null) {
+    return;
+  }
+
+  const { request, respondWith } = requestEvent;
+  const url = new URL(request.url);
+  switch (url.pathname) {
+    case "/livereload.js":
+      respondWith(
+        new Response(`
         window.onload = () => {
           new WebSocket("ws://localhost:${port}/livereload").onmessage = () => location.reload();
         };
-      `,
-      });
-      continue;
+      `),
+      ).then(
+        () => httpConn.close(),
+        logger.error,
+      );
+      break;
+    case "/livereload": {
+      logger.error(request.headers);
+      const { response, socket } = Deno.upgradeWebSocket(request);
+      handleWs(socket, eventtarget);
+      respondWith(response);
+      break;
     }
-    const { conn, r: bufReader, w: bufWriter, headers } = req;
-    logger.debug(req);
-    acceptWebSocket({
-      conn,
-      bufReader,
-      bufWriter,
-      headers,
-    })
-      .then((ws) => handleWs(ws, eventtarget))
-      .catch(async (err) => {
-        logger.error(`failed to accept websocket: ${err}`);
-        await req.respond({ status: 400 });
-      });
+    default:
+      httpConn.close();
+      break;
   }
+}
+
+interface LivereloadServer {
+  close(): Promise<void>;
+}
+
+export function livereloadServer(
+  port = 35729,
+  eventtarget: EventTarget,
+): LivereloadServer {
+  logger.debug(`livereload websocket server is running on port=${port}`);
+  const listener = Deno.listen({ port });
+  const done = (async () => {
+    for await (const conn of listener) {
+      const httpConn = Deno.serveHttp(conn);
+      serve(httpConn, eventtarget, port).catch(logger.error);
+    }
+  })();
+
+  return {
+    async close() {
+      listener.close();
+      await done;
+    },
+  };
 }

--- a/livereload_server.ts
+++ b/livereload_server.ts
@@ -56,7 +56,6 @@ async function serve(
       );
       break;
     case "/livereload": {
-      logger.error(request.headers);
       const { response, socket } = Deno.upgradeWebSocket(request);
       handleWs(socket, eventtarget);
       respondWith(response);

--- a/livereload_server_test.ts
+++ b/livereload_server_test.ts
@@ -1,0 +1,39 @@
+import { livereloadServer } from "./livereload_server.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  deferred,
+} from "./test_deps.ts";
+
+Deno.test("livereloadServer", async () => {
+  const port = 34567;
+  const eventtarget = new EventTarget();
+  const server = livereloadServer(port, eventtarget);
+  try {
+    const wsURL = `ws://localhost:${port}`;
+
+    // Livereload server should serve livereload.js
+    const res = await fetch(`http://localhost:${port}/livereload.js`);
+    const text = await res.text();
+    assertStringIncludes(text, `new WebSocket("${wsURL}/livereload")`);
+
+    // Livereload server should accept websocket request
+    const done = deferred<void>();
+    let receivedMessage: string | undefined;
+    const ws = new WebSocket(`${wsURL}/livereload`);
+    // Livereload server automatically closes itself when 'built' event is dispatched
+    ws.onclose = () => done.resolve();
+    ws.onopen = () => eventtarget.dispatchEvent(new Event("built"));
+    ws.onmessage = (ev: MessageEvent<string>) => {
+      receivedMessage = ev.data;
+    };
+    ws.onerror = (ev) => done.reject(ev);
+
+    await done;
+    assert(receivedMessage);
+    assertEquals(JSON.parse(receivedMessage), { type: "reload" });
+  } finally {
+    await server.close();
+  }
+});

--- a/livereload_server_test.ts
+++ b/livereload_server_test.ts
@@ -18,11 +18,11 @@ Deno.test("livereloadServer", async () => {
     const text = await res.text();
     assertStringIncludes(text, `new WebSocket("${wsURL}/livereload")`);
 
-    // Livereload server should accept websocket request
+    // Livereload server should accept websocket requests
     const done = deferred<void>();
     let receivedMessage: string | undefined;
     const ws = new WebSocket(`${wsURL}/livereload`);
-    // Livereload server automatically closes itself when 'built' event is dispatched
+    // Livereload server automatically closes a websocket connection when 'built' event is dispatched
     ws.onclose = () => done.resolve();
     ws.onopen = () => eventtarget.dispatchEvent(new Event("built"));
     ws.onmessage = (ev: MessageEvent<string>) => {

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -3,3 +3,5 @@ export {
   assertEquals,
   assertStringIncludes,
 } from "https://deno.land/std@0.95.0/testing/asserts.ts";
+
+export { deferred } from "https://deno.land/std@0.95.0/async/deferred.ts";


### PR DESCRIPTION
Hi, thank you for creating this awesome module!

This PR migrates live reload server implementation from std/http+std/ws to the native HTTP server.