### PR TITLE
Add support for multiple entrypoints

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -256,11 +256,11 @@ async function serve(
   const onBuild = () => buildEventHub.dispatchEvent(new CustomEvent("built"));
 
   const allAssets: AsyncGenerator<File, void, void>[] = [];
-  for (const path of paths) {
+  for (const [index, path] of paths.entries()) {
     const assets = watchAndGenAssets(path, {
       livereloadPort,
       onBuild,
-      mainAs404: true,
+      mainAs404: index === 0,
     });
     allAssets.push(assets);
   }

--- a/cli.ts
+++ b/cli.ts
@@ -1,4 +1,5 @@
 import {
+  basename,
   ensureDir,
   join,
   NAME,
@@ -209,6 +210,8 @@ async function build(
   paths: string[],
   { distDir, staticDir }: BuildOptions & BuildAndServeCommonOptions,
 ) {
+  checkUniqueEntrypoints(paths);
+
   logger.log(`Writing the assets to ${distDir}`);
   await ensureDir(distDir);
 
@@ -244,6 +247,8 @@ async function serve(
     & ServeOptions
     & BuildAndServeCommonOptions,
 ) {
+  checkUniqueEntrypoints(paths);
+
   // This is used for propagating onBuild event to livereload server.
   const buildEventHub = new EventTarget();
   livereloadServer(livereloadPort, buildEventHub);
@@ -271,6 +276,14 @@ async function serve(
     logger.log(`Server running at http://localhost:${addr.port}`);
   }
   await new Promise(() => {});
+}
+
+function checkUniqueEntrypoints(paths: string[]): void {
+  // Throw if there are any duplicate basenames
+  const uniqueBasenames = new Set(paths.map((p) => basename(p)));
+  if (uniqueBasenames.size !== paths.length) {
+    throw new Error("Duplicate basenames");
+  }
 }
 
 if (import.meta.main) {

--- a/generate_assets.ts
+++ b/generate_assets.ts
@@ -61,7 +61,7 @@ export async function generateAssets(
         { name: "404" },
       );
     }
-    logger.log(`Built in ${Date.now() - buildStarted}ms`);
+    logger.log(`${path} bundled in ${Date.now() - buildStarted}ms`);
 
     // If build hook is set, call it. Used for live reloading.
     opts.onBuild?.();


### PR DESCRIPTION
Changes serve and build to support multiple entrypoint paths by just iterating over each path and doing the bundling as was done before.