### PR TITLE
feat(install_util): add support for `DENO_DIR`

### DIFF
--- a/install_util.ts
+++ b/install_util.ts
@@ -7,8 +7,14 @@ function homedir(os: typeof Deno.build.os): string {
   return Deno.env.get("HOME")!;
 }
 
-export function wasmCacheDir(os = Deno.build.os, getHomeDir = homedir): string {
-  return join(getHomeDir(os), ".deno", NAME);
+export function wasmCacheDir(
+  os = Deno.build.os,
+  getHomeDir = homedir,
+  maybeDenoDir = Deno.env.get("DENO_DIR"),
+): string {
+  return maybeDenoDir
+    ? join(maybeDenoDir, NAME)
+    : join(getHomeDir(os), ".deno", NAME);
 }
 
 export function wasmPath(): string {

--- a/install_util_test.ts
+++ b/install_util_test.ts
@@ -31,6 +31,5 @@ Deno.test({
   },
   permissions: {
     read: ["."],
-    env: ["DENO_DIR"],
   },
 });

--- a/install_util_test.ts
+++ b/install_util_test.ts
@@ -2,19 +2,35 @@ import { assertEquals } from "./test_deps.ts";
 import { join } from "./deps.ts";
 import { wasmCacheDir } from "./install_util.ts";
 
+const homedir = (os: typeof Deno.build.os) =>
+  os === "windows" ? "/userprofile" : "/home/foo";
+
 Deno.test("wasmCacheDir - returns cache dir for esbuild wasm", () => {
-  const homedir = (os: typeof Deno.build.os) =>
-    os === "windows" ? "/userprofile" : "/home/foo";
   assertEquals(
-    wasmCacheDir("windows", homedir),
+    wasmCacheDir("windows", homedir, ""),
     join("/userprofile", ".deno/packup"),
   );
   assertEquals(
-    wasmCacheDir("linux", homedir),
+    wasmCacheDir("linux", homedir, ""),
     join("/home/foo", ".deno/packup"),
   );
   assertEquals(
-    wasmCacheDir("darwin", homedir),
+    wasmCacheDir("darwin", homedir, ""),
     join("/home/foo", ".deno/packup"),
   );
+});
+
+Deno.test({
+  name: "wasmCacheDir - respects DENO_DIR if defined",
+  fn: () => {
+    const denoDir = join(Deno.cwd(), ".deno");
+    const cacheDir = join(denoDir, "packup");
+    assertEquals(wasmCacheDir("windows", homedir, denoDir), cacheDir);
+    assertEquals(wasmCacheDir("linux", homedir, denoDir), cacheDir);
+    assertEquals(wasmCacheDir("darwin", homedir, denoDir), cacheDir);
+  },
+  permissions: {
+    read: ["."],
+    env: ["DENO_DIR"],
+  },
 });


### PR DESCRIPTION
This PR changes `install_util.ts` to install `esbuild.wasm` into `DENO_DIR` if it is defined.