### PR TITLE
feat: add support for import maps

### DIFF
--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -23,9 +23,23 @@ export async function bundleByEsbuild(
 
   const bundle = await build({
     entryPoints: [toFileUrl(resolve(path)).href],
-    plugins: [denoPlugin()],
+    plugins: [
+      denoPlugin({
+        importMapFile: getImportMap(),
+      }),
+    ],
     bundle: true,
   });
 
   return bundle.outputFiles![0].text;
+}
+
+let _importMap: string | undefined;
+
+export function setImportMap(importMap: string) {
+  _importMap = importMap;
+}
+
+export function getImportMap() {
+  return _importMap;
 }

--- a/bundle_util_test.ts
+++ b/bundle_util_test.ts
@@ -1,5 +1,5 @@
-import { assertStringIncludes } from "./test_deps.ts";
-import { bundleByEsbuild } from "./bundle_util.ts";
+import { assertEquals, assertStringIncludes } from "./test_deps.ts";
+import { bundleByEsbuild, setImportMap, getImportMap } from "./bundle_util.ts";
 import { wasmPath } from "./install_util.ts";
 
 Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
@@ -7,3 +7,13 @@ Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
 
   assertStringIncludes(bundle, `console.log("hi");`);
 });
+
+Deno.test(
+  "setImportMap + getImportMap - stores import map for build process",
+  () => {
+    const importMapFile = "./import_map.json";
+    assertEquals(getImportMap(), undefined);
+    setImportMap(importMapFile);
+    assertEquals(getImportMap(), importMapFile);
+  }
+);

--- a/bundle_util_test.ts
+++ b/bundle_util_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertStringIncludes } from "./test_deps.ts";
-import { bundleByEsbuild, setImportMap, getImportMap } from "./bundle_util.ts";
+import { bundleByEsbuild, getImportMap, setImportMap } from "./bundle_util.ts";
 import { wasmPath } from "./install_util.ts";
 
 Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
@@ -15,5 +15,5 @@ Deno.test(
     assertEquals(getImportMap(), undefined);
     setImportMap(importMapFile);
     assertEquals(getImportMap(), importMapFile);
-  }
+  },
 );

--- a/cli.ts
+++ b/cli.ts
@@ -106,7 +106,7 @@ export async function main(cliArgs: string[] = Deno.args): Promise<number> {
     port = "1234",
     "public-url": publicUrl = ".",
     "livereload-port": livereloadPort = 35729,
-    "import-map": importMap = "",
+    "import-map": importMap,
   } = parseFlags(cliArgs, {
     string: [
       "log-level",

--- a/cli.ts
+++ b/cli.ts
@@ -245,7 +245,7 @@ async function build(
     publicUrl,
     staticDistPrefix,
     importMap,
-  }: BuildOptions & BuildAndServeCommonOptions
+  }: BuildOptions & BuildAndServeCommonOptions,
 ) {
   checkUniqueEntrypoints(paths);
   setImportMap(importMap);
@@ -291,7 +291,7 @@ async function serve(
     publicUrl,
     staticDistPrefix,
     importMap,
-  }: ServeOptions & BuildAndServeCommonOptions
+  }: ServeOptions & BuildAndServeCommonOptions,
 ) {
   checkUniqueEntrypoints(paths);
   setImportMap(importMap);

--- a/examples/import-map/css/style.css
+++ b/examples/import-map/css/style.css
@@ -1,0 +1,8 @@
+* {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: yellow;
+}

--- a/examples/import-map/import_map.json
+++ b/examples/import-map/import_map.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "react": "https://esm.sh/react@17.0.2",
+    "react-dom": "https://esm.sh/react-dom@17.0.2",
+    "react-router-dom": "https://esm.sh/react-router-dom@5.2.0"
+  }
+}

--- a/examples/import-map/index.html
+++ b/examples/import-map/index.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>with-simple-assets document</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <script src="js/script.tsx"></script>
+  </head>
+  <body>
+    <div id="main"></div>
+  </body>
+</html>

--- a/examples/import-map/js/script.tsx
+++ b/examples/import-map/js/script.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import {
-  BrowserRouter as Router,
-  Link,
-  Route,
-  Switch,
-} from "react-router-dom";
+import { BrowserRouter as Router, Link, Route, Switch } from "react-router-dom";
 
 function App() {
   return (

--- a/examples/import-map/js/script.tsx
+++ b/examples/import-map/js/script.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import {
+  BrowserRouter as Router,
+  Link,
+  Route,
+  Switch,
+} from "react-router-dom";
+
+function App() {
+  return (
+    <Router>
+      <div>
+        <nav>
+          <ul>
+            <li>
+              <Link to="/">Home</Link>
+            </li>
+            <li>
+              <Link to="/about">About</Link>
+            </li>
+            <li>
+              <Link to="/users">Users</Link>
+            </li>
+          </ul>
+        </nav>
+
+        {
+          /* A <Switch> looks through its children <Route>s and
+            renders the first one that matches the current URL. */
+        }
+        <Switch>
+          <Route path="/about">
+            <About />
+          </Route>
+          <Route path="/users">
+            <Users />
+          </Route>
+          <Route path="/">
+            <Home />
+          </Route>
+        </Switch>
+      </div>
+    </Router>
+  );
+}
+
+function Home() {
+  return <h2>Home</h2>;
+}
+
+function About() {
+  return <h2>About</h2>;
+}
+
+function Users() {
+  return <h2>Users</h2>;
+}
+
+function main() {
+  ReactDOM.render(React.createElement(App), document.querySelector("#main"));
+}
+
+addEventListener("DOMContentLoaded", () => {
+  main();
+});

--- a/examples/import-map/tsconfig.json
+++ b/examples/import-map/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext", "dom"]
+  }
+}


### PR DESCRIPTION
I have implemented support for import maps.

Usage example:
```
packup --import-map import_map.json index.html
```

Works for both `serve` and `build` subcommands.

Packup is a great Deno tool. Thank you for creating it and for considering this PR.