### PR TITLE
chore: updated esbuild to v0.14.51

### DIFF
--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -1,5 +1,5 @@
 import { resolve, toFileUrl } from "./deps.ts";
-import { build, stop } from "https://deno.land/x/esbuild@v0.14.51/wasm.js";
+import { build, stop } from "https://deno.land/x/esbuild@v0.14.51/mod.js";
 import { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.5.2/mod.ts";
 
 export async function bundleByEsbuild(

--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -1,35 +1,28 @@
 import { resolve, toFileUrl } from "./deps.ts";
-import { logger } from "./logger_util.ts";
-import { build, load } from "https://deno.land/x/esbuild_loader@v0.12.8/mod.ts";
-import { denoPlugin } from "./vendor/esbuild_deno_loader/mod.ts";
+import { build, stop } from "https://deno.land/x/esbuild@v0.14.51/wasm.js";
+import { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.5.2/mod.ts";
 
-type Builder = typeof build;
-let b: Builder | null = null;
-async function loadBuilder(wasmPath: string): Promise<Builder> {
-  if (b) {
-    return b;
-  }
-  const start = Date.now();
-  const { build } = await load(wasmPath);
-  logger.debug(`Esbuild loaded in ${Date.now() - start}ms`);
-  b = build;
-  return b;
-}
 export async function bundleByEsbuild(
   path: string,
-  wasmPath: string,
 ): Promise<string> {
-  const build = await loadBuilder(wasmPath);
+  const importMapFile = getImportMap();
+  let importMapURL: URL | undefined;
+  if (importMapFile) {
+    importMapURL = toFileUrl(resolve(importMapFile));
+  }
 
   const bundle = await build({
     entryPoints: [toFileUrl(resolve(path)).href],
     plugins: [
       denoPlugin({
-        importMapFile: getImportMap(),
+        importMapURL,
       }),
     ],
     bundle: true,
+    write: false,
   });
+
+  stop();
 
   return bundle.outputFiles![0].text;
 }

--- a/bundle_util_test.ts
+++ b/bundle_util_test.ts
@@ -1,9 +1,8 @@
 import { assertEquals, assertStringIncludes } from "./test_deps.ts";
 import { bundleByEsbuild, getImportMap, setImportMap } from "./bundle_util.ts";
-import { wasmPath } from "./install_util.ts";
 
 Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
-  const bundle = await bundleByEsbuild("testdata/foo.js", wasmPath());
+  const bundle = await bundleByEsbuild("testdata/foo.js");
 
   assertStringIncludes(bundle, `console.log("hi");`);
 });

--- a/generate_assets.ts
+++ b/generate_assets.ts
@@ -25,7 +25,6 @@ import {
   md5,
   qs,
 } from "./util.ts";
-import { wasmPath } from "./install_util.ts";
 import { bundleByEsbuild } from "./bundle_util.ts";
 import { logger } from "./logger_util.ts";
 import { compile as compileSass } from "./sass_util.ts";
@@ -300,7 +299,7 @@ class ScriptAsset implements Asset {
     pathPrefix,
   }: CreateFileObjectParams): Promise<File[]> {
     const path = join(base, this.#src);
-    const data = await bundleByEsbuild(path, wasmPath());
+    const data = await bundleByEsbuild(path);
     this.#dest = `${pageName}.${md5(data)}.js`;
     this.#el.setAttribute("src", join(pathPrefix, this.#dest));
     return [

--- a/install.ts
+++ b/install.ts
@@ -1,9 +1,4 @@
-import { ensureDir, NAME, VERSION } from "./deps.ts";
-import { installWasm, wasmCacheDir } from "./install_util.ts";
-
-await ensureDir(wasmCacheDir());
-
-await installWasm();
+import { NAME, VERSION } from "./deps.ts";
 
 console.log(`Installing ${NAME} command`);
 const p = Deno.run({


### PR DESCRIPTION
I have attempted to update packup with newer version of `esbuild`, using the official Deno module. The included version is the same one as supported by `esbuild_deno_loader` (the newest version of esbuild does not work because of a change in interface).

One big feature that is enabled by this PR is support for TypeScript type-only specifiers (see https://esbuild.github.io/content-types/#typescript) so you can write code like:
```ts
import { type SomeType, someVar } from "./mod.ts"
``` 

The code uses native build of esbuild instead of WASM because of performance. According to my testing the WASM version is cca 3 - 5 times slower than native version.

In this PR:
- `esbuild_loader` is replaced with `https://deno.land/x/esbuild@v0.14.51`
- vendored `esbuild_deno_loader` replaced with `https://deno.land/x/esbuild_deno_loader@0.5.2`.
- install script does not cache esbuild.wasm file

What may be possibly removed further (legacy code that I have not dared to delete):
- `install_utils.ts` and `install_util_test.ts`
- `vendor/esbuild_deno_loader`
- `ensure_esbuild_wasm.ts` and references from Makefile