### PR TITLE
chore: migrate sass to latest dart-sass

### DIFF
--- a/sass_util.ts
+++ b/sass_util.ts
@@ -6,16 +6,8 @@ export async function compile(text: string): Promise<string> {
   // Use dynamic import because sass.js is slow to import
   const start = performance.now();
   console.log("Importing sass");
-  const { Sass } = await import("./vendor/" + "sass/mod.ts");
+  const sass = await import("npm:sass@1.77.2");
   console.log(`Imported sass in ${(performance.now() - start).toFixed(1)}ms`);
-  return new Promise((resolve, reject) => {
-    // deno-lint-ignore no-explicit-any
-    Sass.compile(text, (result: any) => {
-      if (result.status === 0) {
-        resolve(result.text);
-      } else {
-        reject(new Error(result.message));
-      }
-    });
-  });
+  const result = await sass.compileStringAsync(text);
+  return result.css;
 }

--- a/sass_util_test.ts
+++ b/sass_util_test.ts
@@ -5,5 +5,5 @@ Deno.test("sass_util - compile", async () => {
   const scss = ".foo { &__bar { margin: 0; } }";
   const css = await compile(scss);
 
-  assertEquals(css, ".foo__bar {\n  margin: 0; }\n");
+  assertEquals(css, ".foo__bar {\n  margin: 0;\n}");
 });

--- a/vendor/sass/mod.ts
+++ b/vendor/sass/mod.ts
@@ -1,4 +1,0 @@
-import "./sass.js";
-
-// deno-lint-ignore no-explicit-any
-export const Sass: any = (globalThis as any).Sass;


### PR DESCRIPTION
This PR removes legacy sass compiler with latest dart sass via npm. Vendoring sass compiler is no longer necessary.