### PR TITLE
chore: update standard libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-      - uses: denoland/setup-deno@v1.0.0
+      - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
       - run: deno fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/cli.ts
+++ b/cli.ts
@@ -4,7 +4,7 @@ import {
   join,
   NAME,
   opn,
-  parseFlags,
+  parseArgs,
   red,
   serveIterable,
   VERSION,
@@ -111,7 +111,7 @@ export async function main(cliArgs: string[] = Deno.args): Promise<number> {
     "livereload-port": livereloadPort = 35729,
     "import-map": importMap,
     "config": config,
-  } = parseFlags(cliArgs, {
+  } = parseArgs(cliArgs, {
     string: [
       "log-level",
       "out-dir",

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,5 @@
 export { crypto } from "jsr:@std/crypto@0.224.0/crypto";
+export { parseArgs } from "jsr:@std/cli@0.224.4/parse-args";
 export {
   basename,
   dirname,
@@ -11,7 +12,6 @@ export {
 export { join as posixPathJoin } from "jsr:@std/path@0.225.1/posix";
 export { parse as parseJsonC } from "jsr:@std/jsonc@0.224.0";
 export { ensureDir, exists, walk } from "jsr:@std/fs@0.229.1";
-export { parse as parseFlags } from "jsr:@std/flags@0.224.0";
 export { red } from "jsr:@std/fmt@0.225.2/colors";
 export { MuxAsyncIterator } from "jsr:@std/async@0.224.1";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,4 @@
 export { crypto } from "jsr:@std/crypto@0.224.0/crypto";
-
 export {
   basename,
   dirname,
@@ -8,18 +7,16 @@ export {
   relative,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.155.0/path/mod.ts";
-export { parse as parseJsonC } from "https://deno.land/std@0.193.0/jsonc/mod.ts";
-import { join } from "https://deno.land/std@0.155.0/path/posix.ts";
-export { join as posixPathJoin };
+} from "jsr:@std/path@0.225.1";
+export { join as posixPathJoin } from "jsr:@std/path@0.225.1/posix";
+export { parse as parseJsonC } from "jsr:@std/jsonc@0.224.0";
+export { ensureDir, exists, walk } from "jsr:@std/fs@0.229.1";
+export { parse as parseFlags } from "jsr:@std/flags@0.224.0";
+export { red } from "jsr:@std/fmt@0.225.2/colors";
+export { MuxAsyncIterator } from "jsr:@std/async@0.224.1";
+
 export { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.1/mod.ts";
 export { build, stop } from "https://deno.land/x/esbuild@v0.17.19/mod.js";
-export { exists } from "https://deno.land/std@0.194.0/fs/mod.ts";
-export { ensureDir } from "https://deno.land/std@0.155.0/fs/ensure_dir.ts";
-export { parse as parseFlags } from "https://deno.land/std@0.155.0/flags/mod.ts";
-export { red } from "https://deno.land/std@0.155.0/fmt/colors.ts";
-export { MuxAsyncIterator } from "https://deno.land/std@0.155.0/async/mux_async_iterator.ts";
-export { walk } from "https://deno.land/std@0.155.0/fs/walk.ts";
 
 export {
   Document,

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,5 @@
-export { createHash } from "https://deno.land/std@0.155.0/hash/mod.ts";
+export { crypto } from "jsr:@std/crypto@0.224.0/crypto";
+
 export {
   basename,
   dirname,

--- a/livereload_server.ts
+++ b/livereload_server.ts
@@ -90,6 +90,8 @@ export function livereloadServer(
   const listener = Deno.listen({ port });
   const done = (async () => {
     for await (const conn of listener) {
+      // TODO: migrate to Deno.serve
+      // deno-lint-ignore no-deprecated-deno-api
       const httpConn = Deno.serveHttp(conn);
       serve(httpConn, eventtarget, port).catch(logger.error);
     }

--- a/util.ts
+++ b/util.ts
@@ -1,6 +1,6 @@
 import {
   basename,
-  createHash,
+  crypto,
   Document,
   Element,
   fromFileUrl,
@@ -11,9 +11,12 @@ export const decoder = new TextDecoder();
 export const encoder = new TextEncoder();
 
 export function md5(data: string | ArrayBuffer): string {
-  const hash = createHash("md5");
-  hash.update(data);
-  return hash.toString();
+  const digest = crypto.subtle.digestSync(
+    "MD5",
+    typeof data === "string" ? new TextEncoder().encode(data) : data,
+  );
+  const byteArray = Array.from(new Uint8Array(digest));
+  return byteArray.map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 export async function getDependencies(path: string): Promise<string[]> {


### PR DESCRIPTION
* update std libraries
* replace legacy `std/hash` module with `@std/crypto`
* replace deprecated `@std/flags` module with `@std/cli/parse-args`