### PR TITLE
Add option `--no-bundle`

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -4,5 +4,4 @@ about: Describe this issue template's purpose here.
 title: ''
 labels: ''
 assignees: ''
-
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.** A clear and

--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -9,8 +9,15 @@ import {
   toFileUrl,
 } from "./deps.ts";
 
+type EsbuildOptions = {
+  noBundle: boolean;
+};
+
 export async function bundleByEsbuild(
   path: string,
+  {
+    noBundle,
+  }: EsbuildOptions
 ): Promise<string> {
   const importMapFile = getImportMap();
   let importMapURL: URL | undefined;
@@ -58,7 +65,7 @@ export async function bundleByEsbuild(
         importMapURL: importMapURL?.href,
       }),
     ],
-    bundle: true,
+    bundle: !noBundle,
     write: false,
     jsx,
     jsxFactory,

--- a/bundle_util.ts
+++ b/bundle_util.ts
@@ -17,7 +17,7 @@ export async function bundleByEsbuild(
   path: string,
   {
     noBundle,
-  }: EsbuildOptions
+  }: EsbuildOptions,
 ): Promise<string> {
   const importMapFile = getImportMap();
   let importMapURL: URL | undefined;

--- a/bundle_util_test.ts
+++ b/bundle_util_test.ts
@@ -10,7 +10,7 @@ Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
 Deno.test("bundleByEsbuild - builds without bundling the script by esbuild", async () => {
   const bundle = await bundleByEsbuild("testdata/foo.js", { noBundle: true });
 
-  assert(!bundle.includes(`console.log("hi");`) && bundle.includes('bar.js'));
+  assert(!bundle.includes(`console.log("hi");`) && bundle.includes("bar.js"));
 });
 
 Deno.test(

--- a/bundle_util_test.ts
+++ b/bundle_util_test.ts
@@ -1,10 +1,16 @@
-import { assertEquals, assertStringIncludes } from "./test_deps.ts";
+import { assert, assertEquals, assertStringIncludes } from "./test_deps.ts";
 import { bundleByEsbuild, getImportMap, setImportMap } from "./bundle_util.ts";
 
 Deno.test("bundleByEsbuild - bundles the script by esbuild", async () => {
-  const bundle = await bundleByEsbuild("testdata/foo.js");
+  const bundle = await bundleByEsbuild("testdata/foo.js", { noBundle: false });
 
   assertStringIncludes(bundle, `console.log("hi");`);
+});
+
+Deno.test("bundleByEsbuild - builds without bundling the script by esbuild", async () => {
+  const bundle = await bundleByEsbuild("testdata/foo.js", { noBundle: true });
+
+  assert(!bundle.includes(`console.log("hi");`) && bundle.includes('bar.js'));
 });
 
 Deno.test(

--- a/cli.ts
+++ b/cli.ts
@@ -51,6 +51,7 @@ Options:
   -i, --import-map <file>         The path to an import map file.
   -c, --config <file>             The path to a tsconfig file.
   -o, --open                      Automatically opens in specified browser.
+  --no-bundle                     Do not bundle any files.
   TODO --https                    Serves files over HTTPS.
   TODO --cert <path>              The path to certificate to use with HTTPS.
   TODO --key <path>               The path to private key to use with HTTPS.
@@ -72,6 +73,7 @@ Options:
   --public-url <prefix>           The path prefix for urls. Default is ".".
   -i, --import-map <file>         The path to an import map file.
   -c, --config <file>             The path to a tsconfig file.
+  --no-bundle                     Do not bundle any files.
   -L, --log-level <level>         Set the log level (choices: "none", "error", "warn", "info", "verbose")
   -h, --help                      Display help for command
 `.trim());
@@ -91,6 +93,7 @@ type CliArgs = {
   "static-dist-prefix": string;
   "import-map": string;
   "config": string;
+  "no-bundle": boolean;
 };
 
 /**
@@ -111,6 +114,7 @@ export async function main(cliArgs: string[] = Deno.args): Promise<number> {
     "livereload-port": livereloadPort = 35729,
     "import-map": importMap,
     "config": config,
+    "no-bundle": noBundle,
   } = parseArgs(cliArgs, {
     string: [
       "log-level",
@@ -121,7 +125,7 @@ export async function main(cliArgs: string[] = Deno.args): Promise<number> {
       "import-map",
       "config",
     ],
-    boolean: ["help", "version", "open"],
+    boolean: ["help", "version", "open", "no-bundle"],
     alias: {
       h: "help",
       v: "version",
@@ -199,6 +203,7 @@ export async function main(cliArgs: string[] = Deno.args): Promise<number> {
       staticDistPrefix,
       importMap,
       config,
+      noBundle,
     });
     return 0;
   }
@@ -227,6 +232,7 @@ export async function main(cliArgs: string[] = Deno.args): Promise<number> {
     staticDistPrefix,
     importMap,
     config,
+    noBundle,
   });
   return 0;
 }
@@ -237,6 +243,7 @@ type BuildAndServeCommonOptions = {
   publicUrl: string;
   importMap: string;
   config: string;
+  noBundle: boolean;
 };
 
 type BuildOptions = {
@@ -255,6 +262,7 @@ async function build(
     staticDistPrefix,
     importMap,
     config,
+    noBundle,
   }: BuildOptions & BuildAndServeCommonOptions,
 ) {
   checkUniqueEntrypoints(paths);
@@ -269,7 +277,7 @@ async function build(
   });
   const allAssets: AsyncGenerator<File, void, void>[] = [];
   for (const path of paths) {
-    const [assets] = await generateAssets(path, { publicUrl });
+    const [assets] = await generateAssets(path, { publicUrl, noBundle });
     allAssets.push(assets);
   }
 
@@ -304,6 +312,7 @@ async function serve(
     staticDistPrefix,
     importMap,
     config,
+    noBundle,
   }: ServeOptions & BuildAndServeCommonOptions,
 ) {
   checkUniqueEntrypoints(paths);
@@ -328,6 +337,7 @@ async function serve(
       onBuild,
       mainAs404: index === 0,
       publicUrl,
+      noBundle,
     });
     allAssets.push(assets);
   }

--- a/docs/getting-started/cli-command.md
+++ b/docs/getting-started/cli-command.md
@@ -31,7 +31,10 @@ Options:
   -s, --static-dir <dir>          The directory for static files. The files here are served as is.
   --static-dist-prefix <prefix>   The prefix for static files in the destination.
   --public-url <prefix>           The path prefix for urls. Default is ".".
+  -i, --import-map <file>         The path to an import map file.
+  -c, --config <file>             The path to a tsconfig file.
   -o, --open                      Automatically opens in specified browser.
+  --no-bundle                     Do not bundle any files.
   --log-level <level>             Sets the log level. "error", "warn", "info", "debug" or "trace". Default is "info".
   -h, --help                      Displays help for command.
 ```
@@ -65,6 +68,9 @@ Options:
   -s, --static-dir <dir>          The directory for static files. The files here are copied to dist as is.
   --static-dist-prefix <prefix>   The prefix for static files in the destination.
   --public-url <prefix>           The path prefix for urls. Default is ".".
+  -i, --import-map <file>         The path to an import map file.
+  -c, --config <file>             The path to a tsconfig file.
+  --no-bundle                     Do not bundle any files.
   -L, --log-level <level>         Set the log level (choices: "none", "error", "warn", "info", "verbose")
   -h, --help                      Display help for command
 ```

--- a/generate_assets.ts
+++ b/generate_assets.ts
@@ -73,7 +73,12 @@ export async function generateAssets(
   const generator = (async function* () {
     for (const a of assets) {
       // TODO(kt3k): These can be concurrent
-      const files = await a.createFileObject({ pageName, base, pathPrefix, noBundle });
+      const files = await a.createFileObject({
+        pageName,
+        base,
+        pathPrefix,
+        noBundle,
+      });
       for (const file of files) yield file;
     }
 
@@ -86,8 +91,12 @@ export async function generateAssets(
     });
     for (const file of files) yield file;
     if (opts.mainAs404) {
-      const file =
-        (await htmlAsset.createFileObject({ pageName, base, pathPrefix, noBundle }))[0];
+      const file = (await htmlAsset.createFileObject({
+        pageName,
+        base,
+        pathPrefix,
+        noBundle,
+      }))[0];
 
       yield new File([await file.arrayBuffer()], "404", {
         lastModified: 0,

--- a/generate_assets_test.ts
+++ b/generate_assets_test.ts
@@ -57,6 +57,7 @@ Deno.test("extractReferencedAssets - references to http(s):// schemes are treate
 Deno.test("generateAssets", async () => {
   const [gen] = await generateAssets("examples/with-imports/index.html", {
     publicUrl: ".",
+    noBundle: false,
   });
   const assets = [];
   for await (const asset of gen) {
@@ -81,6 +82,7 @@ Deno.test("generateAssets", async () => {
 Deno.test("generateAssets - publicUrl=/", async () => {
   const [gen] = await generateAssets("examples/with-imports/index.html", {
     publicUrl: "/",
+    noBundle: false,
   });
   const assets = [];
   for await (const asset of gen) {


### PR DESCRIPTION
Adds support for the option `--no-bundle`, equivalent to using esbuild without `--bundle`.

Closes #66.